### PR TITLE
Filter using absolute record ids

### DIFF
--- a/PowerSiem.ps1
+++ b/PowerSiem.ps1
@@ -33,185 +33,182 @@ Function Write-Alert ($alerts) {
 
 $LogName = "Microsoft-Windows-Sysmon"
 
-$index =  (Get-WinEvent -Provider "Microsoft-Windows-Sysmon" -max 1).RecordID
+$maxRecordId = (Get-WinEvent -Provider $LogName -max 1).RecordID
+
 while ($true)
 {
     Start-Sleep 1
 
-    $NewIndex = (Get-WinEvent -Provider $LogName -max 1).RecordID
+    $xPath = "*[System[EventRecordID > $maxRecordId]]"
+    $logs = Get-WinEvent -Provider $LogName -FilterXPath $xPath | Sort-Object RecordID
 
-    if ($NewIndex -gt $Index) {
-        # We Have New Events.
-        $logs =  Get-WinEvent -provider $LogName -max ($NewIndex - $index) | sort RecordID
-        foreach($log in $logs) {
-            $evt = $log | Parse-Event
-            if ($evt.id -eq 1) {
-                $output = @{}
-                $output.add("Type", "Process Create")
-                $output.add("PID", $evt.ProcessId)
-                $output.add("Image", $evt.Image)
-                $output.add("CommandLine", $evt.CommandLine)
-                $output.add("CurrentDirectory", $evt.CurrentDirectory)
-                $output.add("User", $evt.User)
-                $output.add("ParentImage", $evt.ParentImage)
-                $output.add("ParentCommandLine", $evt.ParentCommandLine)
-                $output.add("ParentUser", $evt.ParentUser)
-                write-alert $output
-            }
-            if ($evt.id -eq 2) {
-                $output = @{}
-                $output.add("Type", "File Creation Time Changed")
-                $output.add("PID", $evt.ProcessId)
-                $output.add("Image", $evt.Image)
-                $output.add("TargetFilename", $evt.TargetFileName)
-                $output.add("CreationUtcTime", $evt.CreationUtcTime)
-                $output.add("PreviousCreationUtcTime", $evt.PreviousCreationUtcTime)
-                write-alert $output
-            }
-            if ($evt.id -eq 3) {
-                $output = @{}
-                $output.add("Type", "Network Connection")
-                $output.add("Image", $evt.Image)
-                $output.add("DestinationIp", $evt.DestinationIp)
-                $output.add("DestinationPort", $evt.DestinationPort)                           
-                $output.add("DestinationHost", $evt.DestinationHostname)
-                write-alert $output
-            }
-            if ($evt.id -eq 5) {
-                $output = @{}
-                $output.add("Type", "Process Ended")
-                $output.add("PID", $evt.ProcessId)
-                $output.add("Image", $evt.Image)
-                $output.add("CommandLine", $evt.CommandLine)
-                $output.add("CurrentDirectory", $evt.CurrentDirectory)
-                $output.add("User", $evt.User)
-                $output.add("ParentImage", $evt.ParentImage)
-                $output.add("ParentCommandLine", $evt.ParentCommandLine)
-                $output.add("ParentUser", $evt.ParentUser)
-                write-alert $output
-            }
-            if ($evt.id -eq 6) {
-                $output = @{}
-                $output.add("Type", "Driver Loaded")
-                write-alert $output
-            }
-            if ($evt.id -eq 7) {
-                $output = @{}
-                $output.add("Type", "DLL Loaded By Process")
-                write-alert $output
-            }
-            if ($evt.id -eq 8) {
-                $output = @{}
-                $output.add("Type", "Remote Thread Created")
-                write-alert $output
-            }
-            if ($evt.id -eq 9) {
-                $output = @{}
-                $output.add("Type", "Raw Disk Access")
-                write-alert $output
-            }
-            if ($evt.id -eq 10) {
-                $output = @{}
-                $output.add("Type", "Inter-Process Access")
-                write-alert $output
-            }
-            if ($evt.id -eq 11) {
-                $output = @{}
-                $output.add("Type", "File Create")
-                $output.add("RecordID", $evt.RecordID)
-                $output.add("TargetFilename", $evt.TargetFileName)
-                $output.add("User", $evt.User)
-                $output.add("Process", $evt.Image)
-                $output.add("PID", $evt.ProcessID)                
-                write-alert $output
-            }
-            if ($evt.id -eq 12) {
-                $output = @{}
-                $output.add("Type", "Registry Added or Deleted")
-                write-alert $output
-            }
-            if ($evt.id -eq 13) {
-                $output = @{}
-                $output.add("Type", "Registry Set")
-                write-alert $output
-            }
-            if ($evt.id -eq 14) {
-                $output = @{}
-                $output.add("Type", "Registry Object Renamed")
-                write-alert $output
-            }
-            if ($evt.id -eq 15) {
-                $output = @{}
-                $output.add("Type", "ADFS Created")
-                write-alert $output
-            }
-            if ($evt.id -eq 16) {
-                $output = @{}
-                $output.add("Type", "Sysmon Configuration Change")
-                write-alert $output
-            }
-            if ($evt.id -eq 17) {
-                $output = @{}
-                $output.add("Type", "Pipe Created")
-                write-alert $output
-            }
-            if ($evt.id -eq 18) {
-                $output = @{}
-                $output.add("Type", "Pipe Connected")
-                write-alert $output
-            }
-            if ($evt.id -eq 19) {
-                $output = @{}
-                $output.add("Type", "WMI Event Filter Activity")
-                write-alert $output
-            }
-            if ($evt.id -eq 20) {
-                $output = @{}
-                $output.add("Type", "WMI Event Consumer Activity")
-                write-alert $output
-            }
-            if ($evt.id -eq 21) {
-                $output = @{}
-                $output.add("Type", "WMI Event Consumer To Filter Activity")
-                write-alert $output
-            }
-            if ($evt.id -eq 22) {
-                $output = @{}
-                $output.add("Type", "DNS Query")
-                write-alert $output
-            }
-            if ($evt.id -eq 23) {
-                $output = @{}
-                $output.add("Type", "File Delete")
-                $output.add("RecordID", $evt.RecordID)
-                $output.add("TargetFilename", $evt.TargetFileName)
-                $output.add("User", $evt.User)
-                $output.add("Process", $evt.Image)
-                $output.add("PID", $evt.ProcessID)                
-                write-alert $output
-            }
-            if ($evt.id -eq 24) {
-                $output = @{}
-                $output.add("Type", "Clipboard Event Monitor")
-                write-alert $output
-            }
-            if ($evt.id -eq 25) {
-                $output = @{}
-                $output.add("Type", "Process Tamper")
-                write-alert $output
-            }
-            if ($evt.id -eq 26) {
-                $output = @{}
-                $output.add("Type", "File Delete Logged")
-                $output.add("RecordID", $evt.RecordID)
-                $output.add("TargetFilename", $evt.TargetFileName)
-                $output.add("User", $evt.User)
-                $output.add("Process", $evt.Image)
-                $output.add("PID", $evt.ProcessID)                
-                write-alert $output
-            }
-            
+    foreach ($log in $logs) {
+        $evt = $log | Parse-Event
+        if ($evt.id -eq 1) {
+            $output = @{}
+            $output.add("Type", "Process Create")
+            $output.add("PID", $evt.ProcessId)
+            $output.add("Image", $evt.Image)
+            $output.add("CommandLine", $evt.CommandLine)
+            $output.add("CurrentDirectory", $evt.CurrentDirectory)
+            $output.add("User", $evt.User)
+            $output.add("ParentImage", $evt.ParentImage)
+            $output.add("ParentCommandLine", $evt.ParentCommandLine)
+            $output.add("ParentUser", $evt.ParentUser)
+            write-alert $output
         }
-        $index = $NewIndex
+        if ($evt.id -eq 2) {
+            $output = @{}
+            $output.add("Type", "File Creation Time Changed")
+            $output.add("PID", $evt.ProcessId)
+            $output.add("Image", $evt.Image)
+            $output.add("TargetFilename", $evt.TargetFileName)
+            $output.add("CreationUtcTime", $evt.CreationUtcTime)
+            $output.add("PreviousCreationUtcTime", $evt.PreviousCreationUtcTime)
+            write-alert $output
+        }
+        if ($evt.id -eq 3) {
+            $output = @{}
+            $output.add("Type", "Network Connection")
+            $output.add("Image", $evt.Image)
+            $output.add("DestinationIp", $evt.DestinationIp)
+            $output.add("DestinationPort", $evt.DestinationPort)
+            $output.add("DestinationHost", $evt.DestinationHostname)
+            write-alert $output
+        }
+        if ($evt.id -eq 5) {
+            $output = @{}
+            $output.add("Type", "Process Ended")
+            $output.add("PID", $evt.ProcessId)
+            $output.add("Image", $evt.Image)
+            $output.add("CommandLine", $evt.CommandLine)
+            $output.add("CurrentDirectory", $evt.CurrentDirectory)
+            $output.add("User", $evt.User)
+            $output.add("ParentImage", $evt.ParentImage)
+            $output.add("ParentCommandLine", $evt.ParentCommandLine)
+            $output.add("ParentUser", $evt.ParentUser)
+            write-alert $output
+        }
+        if ($evt.id -eq 6) {
+            $output = @{}
+            $output.add("Type", "Driver Loaded")
+            write-alert $output
+        }
+        if ($evt.id -eq 7) {
+            $output = @{}
+            $output.add("Type", "DLL Loaded By Process")
+            write-alert $output
+        }
+        if ($evt.id -eq 8) {
+            $output = @{}
+            $output.add("Type", "Remote Thread Created")
+            write-alert $output
+        }
+        if ($evt.id -eq 9) {
+            $output = @{}
+            $output.add("Type", "Raw Disk Access")
+            write-alert $output
+        }
+        if ($evt.id -eq 10) {
+            $output = @{}
+            $output.add("Type", "Inter-Process Access")
+            write-alert $output
+        }
+        if ($evt.id -eq 11) {
+            $output = @{}
+            $output.add("Type", "File Create")
+            $output.add("RecordID", $evt.RecordID)
+            $output.add("TargetFilename", $evt.TargetFileName)
+            $output.add("User", $evt.User)
+            $output.add("Process", $evt.Image)
+            $output.add("PID", $evt.ProcessID)
+            write-alert $output
+        }
+        if ($evt.id -eq 12) {
+            $output = @{}
+            $output.add("Type", "Registry Added or Deleted")
+            write-alert $output
+        }
+        if ($evt.id -eq 13) {
+            $output = @{}
+            $output.add("Type", "Registry Set")
+            write-alert $output
+        }
+        if ($evt.id -eq 14) {
+            $output = @{}
+            $output.add("Type", "Registry Object Renamed")
+            write-alert $output
+        }
+        if ($evt.id -eq 15) {
+            $output = @{}
+            $output.add("Type", "ADFS Created")
+            write-alert $output
+        }
+        if ($evt.id -eq 16) {
+            $output = @{}
+            $output.add("Type", "Sysmon Configuration Change")
+            write-alert $output
+        }
+        if ($evt.id -eq 17) {
+            $output = @{}
+            $output.add("Type", "Pipe Created")
+            write-alert $output
+        }
+        if ($evt.id -eq 18) {
+            $output = @{}
+            $output.add("Type", "Pipe Connected")
+            write-alert $output
+        }
+        if ($evt.id -eq 19) {
+            $output = @{}
+            $output.add("Type", "WMI Event Filter Activity")
+            write-alert $output
+        }
+        if ($evt.id -eq 20) {
+            $output = @{}
+            $output.add("Type", "WMI Event Consumer Activity")
+            write-alert $output
+        }
+        if ($evt.id -eq 21) {
+            $output = @{}
+            $output.add("Type", "WMI Event Consumer To Filter Activity")
+            write-alert $output
+        }
+        if ($evt.id -eq 22) {
+            $output = @{}
+            $output.add("Type", "DNS Query")
+            write-alert $output
+        }
+        if ($evt.id -eq 23) {
+            $output = @{}
+            $output.add("Type", "File Delete")
+            $output.add("RecordID", $evt.RecordID)
+            $output.add("TargetFilename", $evt.TargetFileName)
+            $output.add("User", $evt.User)
+            $output.add("Process", $evt.Image)
+            $output.add("PID", $evt.ProcessID)
+            write-alert $output
+        }
+        if ($evt.id -eq 24) {
+            $output = @{}
+            $output.add("Type", "Clipboard Event Monitor")
+            write-alert $output
+        }
+        if ($evt.id -eq 25) {
+            $output = @{}
+            $output.add("Type", "Process Tamper")
+            write-alert $output
+        }
+        if ($evt.id -eq 26) {
+            $output = @{}
+            $output.add("Type", "File Delete Logged")
+            $output.add("RecordID", $evt.RecordID)
+            $output.add("TargetFilename", $evt.TargetFileName)
+            $output.add("User", $evt.User)
+            $output.add("Process", $evt.Image)
+            $output.add("PID", $evt.ProcessID)
+            write-alert $output
+        }
+        $maxRecordId = $evt.RecordId
     }
 }


### PR DESCRIPTION
This change fixes a race condition that exists when using the record ids to retrieve the last n events. If events are logged between the 2 calls to Get-WinEvent some events may be missed and some doubled.

The change uses the absolute record ids to retrieve all events since the last one we saw. No math, no races.

I know it's just a POC, but useful code gets copied so I thought the change worthwhile.

There are really just a couple material changes, most of the diff is whitespace changes due to unindenting a block.